### PR TITLE
Fix provisioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: go
+go: 1.5
+sudo: false
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 	godep go install
 
 test:
-	GOTEST=1 godep go test -v dockermachine*
+	GOTEST=1 go test -v dockermachine*
 
 
 .PHONY: build clean test install

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install:
 	godep go install
 
 test:
-	GOTEST=1 godep go test -v ./...
+	GOTEST=1 godep go test -v dockermachine*
 
 
 .PHONY: build clean test install

--- a/dockermachine.go
+++ b/dockermachine.go
@@ -7,6 +7,24 @@ import (
 	"os/exec"
 )
 
+func Provision(machineName string, verbose bool) {
+	if _, err := RunSSHCommand(machineName, "which rsync", verbose); err != nil {
+		installCommands := []string{
+			// install and run rsync daemon
+			`tce-load -wi rsync attr acl`,
+		}
+
+		for _, command := range installCommands {
+			out, err := RunSSHCommand(machineName, command, verbose)
+			if err != nil {
+				fmt.Println(err)
+				fmt.Printf("%s\n", out)
+				os.Exit(1)
+			}
+		}
+	}
+}
+
 func RunSSHCommand(machineName, command string, verbose bool) (out []byte, err error) {
 	if verbose {
 		fmt.Println(`docker-machine ssh ` + machineName + ` '` + command + `'`)

--- a/main.go
+++ b/main.go
@@ -95,6 +95,7 @@ func main() {
 			os.Exit(1)
 		}
 
+		Provision(machineName, *verbose)
 		RunSSHCommand(machineName, "sudo mkdir -p "+rpathDir, *verbose)
 		fmt.Printf("Syncing %s (local) to %s (docker-machine %s)\n", *srcpath, *dstpath, machineName)
 		Sync(machineName, port, rpath, rpathDir, *verbose) // initial sync

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package main
 
-const Version = "0.1.3"
+const Version = "0.1.4"


### PR DESCRIPTION
Conditionally provision the docker machine with rsync. Also change the test make target to only run dockermachine*, which will test on linux. Only OSX can build the fsevents library. I'll explore cross platform filesystem event libraries in the future. It looks like that may also make it into stdlib at some point.

This one looks interesting - https://github.com/rjeczalik/notify
